### PR TITLE
Add ChatGPT-inspired theme and landing page

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,6 +15,10 @@
   document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
 </script>
 
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ base_path }}/assets/css/main.css">
 

--- a/_sass/_chatgpt.scss
+++ b/_sass/_chatgpt.scss
@@ -1,0 +1,40 @@
+/* ChatGPT-inspired dark theme */
+body {
+  background: radial-gradient(circle at 50% 20%, #343541 0%, #171717 100%);
+  color: #e5e5e5;
+  font-family: 'Inter', sans-serif;
+}
+
+a {
+  color: #10a37f;
+
+  &:hover {
+    color: darken(#10a37f, 5%);
+  }
+}
+
+.hero {
+  min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 1.5rem;
+
+  h1 {
+    font-size: 3rem;
+    font-weight: 600;
+    background: linear-gradient(90deg, #10a37f, #0e8a6b);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin: 0;
+  }
+
+  p {
+    font-size: 1.25rem;
+    max-width: 40rem;
+    color: #cfcfcf;
+    margin: 0;
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -39,3 +39,4 @@
 @import "vendor/font-awesome/brands";
 @import "vendor/magnific-popup/magnific-popup";
 @import "print";
+@import "chatgpt";

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Home
+permalink: /
+---
+
+<div class="hero">
+  <h1>ChatGPT-Inspired Elegance</h1>
+  <p>Welcome to my site, reimagined with a sleek and modern touch.</p>
+</div>


### PR DESCRIPTION
## Summary
- add ChatGPT-inspired SCSS theme with dark gradient and hero styles
- load Inter font and apply theme across site
- create simple landing page with hero section

## Testing
- `bundle install`
- `bundle exec jekyll build`
- `npm run build:js`


------
https://chatgpt.com/codex/tasks/task_e_68bb352143e8832ab60466e297f8a880